### PR TITLE
Add test running & deps to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Vega Token
+# Vega Token V2
+
+This will replace [the previous Vega Token](https://github.com/vegaprotocol/vega_token)
 
 # Audit
 Pending. This repository will be updated when the audit is complete.


### PR DESCRIPTION
Very similar commit to https://github.com/vegaprotocol/smart-contracts/pull/2. I'm going to sum up what I've done because I think it will help your workflow, as well as saving me doing this on future repos

### Add a package.json
Why? So that the package doesn't rely on globally installed tools. For me this is mostly about portability - if the dependencies are declared in here, anyone can `git clone` & `npm install` and run the tests without having to look in to the scripts to check the dependencies. It also lets us setup CI to run the tests, but I know you do this solo and locally, so that's less of a concern.

How? I made a package.json file (`npm init`), then ran the tests (from doing the [vegaprotocol/smart-contracts](https://github.com/vegaprotocol/smart-contracts/) work, I knew how. Every time I ran it, it complained about a missing dep, which I installed with `npm add --save-dev ...` which installs it and adds it to the file. Eventually it ran.

### Add `npm scripts` to run the server
This does two things:
- Save a third party from having to work out how to run tests. `npm test` working is a sort of standard expectation (note: that I've failed at, `npm run test:local` works but not `npm test`. This is because I'm a noob with the script in the next point)
- We can avoid telling people to open two terminals using [start-server-and-test](https://www.npmjs.com/package/start-server-and-test) which is pretty neat
- Makes it easy to set up CI

And I mean, running one command is better than two, right? Right.

### Why care about CI?
It's about the repo sending the right message. You've written the tests, let's make it easy for people to see that the tests *exist* and *pass*. It might just be badges and ticks on commits, but given we can get them running as a side effect of the above, it's worth the 5 minutes it takes to copy that over.

# What I didn't fix, and why
## .secrets folder
In [vegaprotocol/smart-contracts](https://github.com/vegaprotocol/smart-contracts/) the mnemonic phrase is hardcoded in the npm script that runs the server. Obviously that sucks if we need to keep the mnemonic secret, but I don't think we do. If we did, we can use Github Secrets and [environment variables](https://www.twilio.com/blog/working-with-environment-variables-in-node-js-html) to manage that in a slightly nicer way that lets you set it locally, and for us to set it for CI, without exposing a mnemonic. In this case, I've just moved it in to `package.json` seeing as it was in a comment in the script and thus already public.

# Why write this giant PR message?
Because I'm going to ask you to start with a package.json in future repos, please. It's a small tweak that won't hugely benefit you, but presents the code we open source in the best light, which makes me happy at least.